### PR TITLE
Add url references to the CID and destination account

### DIFF
--- a/visualizer/src/components/assetInformation/AssetInformation.tsx
+++ b/visualizer/src/components/assetInformation/AssetInformation.tsx
@@ -1,5 +1,6 @@
 import { t } from 'i18next';
 import { IAssetTitle, IAssetInformation } from './interfaces';
+import { IPFS_EXPLORE_URL, EXPERT_ACCOUNT_URL } from '../../utils/constants';
 
 import './styles.css';
 
@@ -19,6 +20,22 @@ const transactionTitles: IAssetTitle[] = [
 
 const IPFSTitles: IAssetTitle[] = [{ key: 'CID', title: 'CID:' }];
 
+const referenceUrl = {
+  destination: EXPERT_ACCOUNT_URL,
+  CID: IPFS_EXPLORE_URL
+};
+
+const formatAssetValue = (key: string, assetValue: string | boolean) => {
+  if (key == 'destination' || key == 'CID') {
+    return (
+      <a href={`${referenceUrl[key]}/${assetValue}`} className="text-blue-600 hover:underline">
+        {String(assetValue).toUpperCase()}
+      </a>
+    );
+  }
+  return String(assetValue).toUpperCase();
+};
+
 const formatAssetInformation = (assetInfo: IAssetInformation, assetTitles: IAssetTitle[]) => {
   return assetTitles.map(({ key, title }, index) => {
     const assetValue = assetInfo[key];
@@ -26,7 +43,7 @@ const formatAssetInformation = (assetInfo: IAssetInformation, assetTitles: IAsse
       <div key={index}>
         <>
           <div className="text-sm font-semibold">{title}</div>
-          <div className="text-xs">{String(assetValue).toUpperCase()}</div>
+          <div className="text-xs">{formatAssetValue(key, assetValue)}</div>
         </>
       </div>
     );

--- a/visualizer/src/components/certificateVisualizer/CertificateVisualizer.tsx
+++ b/visualizer/src/components/certificateVisualizer/CertificateVisualizer.tsx
@@ -25,7 +25,7 @@ const CertificateVisualizer = ({ certificate, id }: CertificateVisualizerProps) 
     return certificateCanvas;
   };
 
-  return <div id={id} className="w-full h-full" />;
+  return <div id={id} className="w-full h-full cursor-move" />;
 };
 
 export default CertificateVisualizer;

--- a/visualizer/src/components/slide/Slide.tsx
+++ b/visualizer/src/components/slide/Slide.tsx
@@ -3,7 +3,7 @@ import { t } from 'i18next';
 import { useParams } from 'react-router-dom';
 import { readCertificate } from '../../ipfs/readCertificate';
 import CertificateVisualizer from '../certificateVisualizer';
-import { PUBLIC_KEY_JANE, PUBLIC_KEY_JOHN, CERTS_TITLES } from '../../utils/constants';
+import { PUBLIC_KEY_JANE, PUBLIC_KEY_JOHN, CERTS_TITLES, DEFAULT_CERT_TITLE } from '../../utils/constants';
 
 const JANE = 'Jane';
 const JONH = 'John';
@@ -61,7 +61,7 @@ const Slide = ({
   const title = CERTS_TITLES[slideIndex - 1].replace('{NAME}', name);
 
   return (
-    <div id={`slide${slideIndex}`} className="w-full h-full carousel-item relative cursor-move">
+    <div id={`slide${slideIndex}`} className="w-full h-full carousel-item relative">
       <div className="card bg-base-100 shadow-xl w-full">
         <div className="relative w-full h-full" style={{ height: 450 }}>
           {certificateJSON && <CertificateVisualizer certificate={certificateJSON} id={`certificate-${slideIndex}`} />}
@@ -93,7 +93,7 @@ const Slide = ({
           <div className="card-actions">
             <div className="lg:flex flex-row justify-between justify-items-end">
               <div className="lg:basis-8/12 basis-6/12">
-                {showTitle && <h1 className="lg:text-3xl text-2xl font-bold mb-6">{title}</h1>}
+                <h1 className="lg:text-3xl text-2xl font-bold mb-6">{showTitle ? title : DEFAULT_CERT_TITLE}</h1>
               </div>
 
               <div className="lg:basis-4/12 basis-6/12 text-right">

--- a/visualizer/src/utils/constants.ts
+++ b/visualizer/src/utils/constants.ts
@@ -6,9 +6,13 @@ export const SMALL_WIDHT = 608;
 export const PUBLIC_KEY_JANE = 'GBAUDP62XLJAE65MHGHPHKGTVN7GICVCFSPYCONVLB7Y357T5NKKYN3P';
 export const PUBLIC_KEY_JOHN = 'GB2HN7F6422JSYTQJ7VMABYSG22QPBEVA25XIKAPGREKK2PSMF4D5F7V';
 
+export const DEFAULT_CERT_TITLE = 'Certificate awarded for being a winner of SCF #12';
 export const CERTS_TITLES = [
   'Certificate awarded to {NAME} Doe for participating in SCF Startup Camp',
   'Certificate awarded to Chaincerts for being a winner of SCF #12',
   'Certificate awarded to {NAME} Doe for being a verified member of the Stellar community',
   'Certificate awarded to {NAME} Doe for completing the Stellar Quest'
 ];
+
+export const IPFS_EXPLORE_URL = 'https://explore.ipld.io/#/explore';
+export const EXPERT_ACCOUNT_URL = 'https://stellar.expert/explorer/testnet/account';


### PR DESCRIPTION
# Context
For each certificate, a reference URL from IPFS explorer and the stellar expert, was added respectively to the CID and the destination account